### PR TITLE
Use `spine-` prefix back again

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ of the "Greater" Model Compiler
 
 ## Related repositories
 
-See [SpineEventEngine/mc-java](https://github.com/SpineEventEngine/mc-java) for the Java-specific
-tools.
+See [SpineEventEngine/mc-java](https://github.com/SpineEventEngine/mc-java) for
+the Java-specific tools.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,9 +78,7 @@ spinePublishing {
         ":plugin-base",
         ":plugin-testlib"
     )
-    // Skip the `spine-` part of the artifact name to avoid collisions with the currently "live"
-    // versions. See https://github.com/SpineEventEngine/model-compiler/issues/3
-    spinePrefix.set(false)
+    spinePrefix.set(true)
 }
 
 allprojects {

--- a/license-report.md
+++ b/license-report.md
@@ -432,7 +432,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 12 19:10:09 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:51:23 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -869,7 +869,7 @@ This report was generated on **Tue Oct 12 19:10:09 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 12 19:10:10 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:51:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1361,7 +1361,7 @@ This report was generated on **Tue Oct 12 19:10:10 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 12 19:10:11 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:51:26 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1766,4 +1766,4 @@ This report was generated on **Tue Oct 12 19:10:11 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 12 19:10:13 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:51:28 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine.tools:model-compiler:0.0.5`
+# Dependencies of `io.spine.tools:spine-model-compiler:0.0.6`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -432,12 +432,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Oct 11 19:52:37 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:10:09 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:plugin-base:0.0.5`
+# Dependencies of `io.spine.tools:spine-plugin-base:0.0.6`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -869,12 +869,12 @@ This report was generated on **Mon Oct 11 19:52:37 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Oct 11 19:52:38 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:10:10 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:plugin-testlib:0.0.5`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:0.0.6`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.8
@@ -1361,12 +1361,12 @@ This report was generated on **Mon Oct 11 19:52:38 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Oct 11 19:52:40 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:10:11 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:tool-base:0.0.5`
+# Dependencies of `io.spine.tools:spine-tool-base:0.0.6`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -1766,4 +1766,4 @@ This report was generated on **Mon Oct 11 19:52:40 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Oct 11 19:52:42 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 12 19:10:13 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/src/main/java/io/spine/tools/gradle/JavaCompileTasks.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/JavaCompileTasks.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle;
+
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.compile.CompileOptions;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Utilities for working with {@link JavaCompile} tasks.
+ */
+@SuppressWarnings("unused")
+public final class JavaCompileTasks {
+
+    private final TaskCollection<JavaCompile> tasks;
+
+    private JavaCompileTasks(Project project) {
+        TaskContainer allTasks = project.getTasks();
+        this.tasks = allTasks.withType(JavaCompile.class);
+    }
+
+    /**
+     * Creates a new instance for the passed projects.
+     */
+    public static JavaCompileTasks of(Project project) {
+        checkNotNull(project);
+        return new JavaCompileTasks(project);
+    }
+
+    /**
+     * Adds specified arguments to all {@code JavaCompile} tasks of the project.
+     */
+    void addArgs(String... arguments) {
+        checkNotNull(arguments);
+        for (JavaCompile task : tasks) {
+            CompileOptions taskOptions = task.getOptions();
+            List<String> compilerArgs = taskOptions.getCompilerArgs();
+            compilerArgs.addAll(Arrays.asList(arguments));
+        }
+    }
+}

--- a/plugin-base/src/main/java/io/spine/tools/gradle/JavaCompileTasks.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/JavaCompileTasks.java
@@ -50,7 +50,7 @@ public final class JavaCompileTasks {
     }
 
     /**
-     * Creates a new instance for the passed projects.
+     * Creates a new instance for the given project.
      */
     public static JavaCompileTasks of(Project project) {
         checkNotNull(project);

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/StandardRepos.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/StandardRepos.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:JvmName("StandardRepos")
+
+package io.spine.tools.gradle
+
+import java.net.URI
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+/**
+ * Adds the standard Maven repositories to the receiver [RepositoryHandler].
+ *
+ * This is analogous to the eponymous method in the build scripts with the exception that this
+ * method is available at the module's test runtime.
+ *
+ * Note that not all the Maven repositories may be added to the test projects, but only those that
+ * are required for tests. We are not trying to keep these repositories is perfect synchrony with
+ * the ones defined in build scripts.
+ */
+public fun RepositoryHandler.applyStandard() {
+    mavenLocal()
+    mavenCentral()
+    val registryBaseUrl = "https://europe-maven.pkg.dev/spine-event-engine"
+    maven {
+        it.url = URI("$registryBaseUrl/releases")
+    }
+    maven {
+        it.url = URI("$registryBaseUrl/snapshots")
+    }
+}

--- a/plugin-base/src/test/java/io/spine/tools/gradle/JavaCompileTasksTest.java
+++ b/plugin-base/src/test/java/io/spine/tools/gradle/JavaCompileTasksTest.java
@@ -26,46 +26,38 @@
 
 package io.spine.tools.gradle;
 
+import io.spine.tools.gradle.given.StubProject;
 import org.gradle.api.Project;
-import org.gradle.api.tasks.TaskCollection;
-import org.gradle.api.tasks.TaskContainer;
-import org.gradle.api.tasks.compile.CompileOptions;
-import org.gradle.api.tasks.compile.JavaCompile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.List;
+import static io.spine.tools.gradle.given.ProjectConfigurations.assertCompileTasksContain;
+import static io.spine.tools.gradle.given.ProjectConfigurations.assertCompileTasksEmpty;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+@DisplayName("`JavaCompileTasks` should")
+class JavaCompileTasksTest {
 
-/**
- * Utilities for working with {@link JavaCompile} tasks.
- */
-public final class JavaCompileTasks {
+    private Project project;
 
-    private final TaskCollection<JavaCompile> tasks;
-
-    private JavaCompileTasks(Project project) {
-        TaskContainer allTasks = project.getTasks();
-        this.tasks = allTasks.withType(JavaCompile.class);
+    @BeforeEach
+    void createProject() {
+        project = StubProject.createFor(getClass()).get();
     }
 
-    /**
-     * Creates a new instance for the passed projects.
-     */
-    public static JavaCompileTasks of(Project project) {
-        checkNotNull(project);
-        return new JavaCompileTasks(project);
+    @Test
+    @DisplayName("add arguments to Java compile tasks")
+    void someArgs() {
+        String firstArg = "firstArg";
+        String secondArg = "secondArg";
+        JavaCompileTasks.of(project).addArgs(firstArg, secondArg);
+        assertCompileTasksContain(project, firstArg, secondArg);
     }
 
-    /**
-     * Adds specified arguments to all {@code JavaCompile} tasks of the project.
-     */
-    public void addArgs(String... arguments) {
-        checkNotNull(arguments);
-        for (JavaCompile task : tasks) {
-            CompileOptions taskOptions = task.getOptions();
-            List<String> compilerArgs = taskOptions.getCompilerArgs();
-            compilerArgs.addAll(Arrays.asList(arguments));
-        }
+    @Test
+    @DisplayName("not add arguments if none is specified")
+    void noArgs() {
+        JavaCompileTasks.of(project).addArgs();
+        assertCompileTasksEmpty(project);
     }
 }

--- a/plugin-base/src/test/java/io/spine/tools/gradle/given/ProjectConfigurations.java
+++ b/plugin-base/src/test/java/io/spine/tools/gradle/given/ProjectConfigurations.java
@@ -64,10 +64,13 @@ public class ProjectConfigurations {
     /**
      * Asserts that the given project's {@link JavaCompile} tasks contain the specified arguments.
      *
-     * @param project the project to check
-     * @param args    the arguments
-     * @throws AssertionError if the any of the project's {@link JavaCompile} tasks do not contain
-     *                        any of the specified arguments
+     * @param project
+     *         the project to check
+     * @param args
+     *         the arguments
+     * @throws AssertionError
+     *         if any of {@link JavaCompile} tasks of the project does not contain
+     *         any of the specified arguments
      */
     public static void assertCompileTasksContain(Project project, String... args) {
         TaskCollection<JavaCompile> javaCompileTasks = acquireJavaCompileTasks(project);

--- a/plugin-base/src/test/java/io/spine/tools/gradle/given/ProjectConfigurations.java
+++ b/plugin-base/src/test/java/io/spine/tools/gradle/given/ProjectConfigurations.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.given;
+
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+import java.util.List;
+
+import static com.google.common.collect.testing.Helpers.assertEmpty;
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.tools.gradle.given.ProjectTasks.acquireJavaCompileTasks;
+import static io.spine.tools.gradle.given.ProjectTasks.obtainCompilerArgs;
+
+/**
+ * A test helper providing various {@code assert...} methods related to the {@link Project}
+ * configurations, tasks and their arguments.
+ */
+public class ProjectConfigurations {
+
+    /** Prevents instantiation of this utility class. */
+    private ProjectConfigurations() {
+    }
+
+    /**
+     * Asserts that the given project has no arguments for its tasks of type {@link JavaCompile}.
+     *
+     * @param project the project to check
+     * @throws AssertionError if the project contains any arguments for compile tasks
+     */
+    public static void assertCompileTasksEmpty(Project project) {
+        TaskCollection<JavaCompile> javaCompileTasks = acquireJavaCompileTasks(project);
+        for (JavaCompile task : javaCompileTasks) {
+            List<String> compilerArgs = obtainCompilerArgs(task);
+            assertEmpty(compilerArgs);
+        }
+    }
+
+    /**
+     * Asserts that the given project's {@link JavaCompile} tasks contain the specified arguments.
+     *
+     * @param project the project to check
+     * @param args    the arguments
+     * @throws AssertionError if the any of the project's {@link JavaCompile} tasks do not contain
+     *                        any of the specified arguments
+     */
+    public static void assertCompileTasksContain(Project project, String... args) {
+        TaskCollection<JavaCompile> javaCompileTasks = acquireJavaCompileTasks(project);
+        for (JavaCompile task : javaCompileTasks) {
+            List<String> compilerArgs = obtainCompilerArgs(task);
+            assertHasAllArgs(compilerArgs, args);
+        }
+    }
+
+    private static void assertHasAllArgs(List<String> compilerArgs, String[] args) {
+        assertThat(compilerArgs).containsAtLeastElementsIn(args);
+    }
+}

--- a/plugin-base/src/test/java/io/spine/tools/gradle/given/ProjectTasks.java
+++ b/plugin-base/src/test/java/io/spine/tools/gradle/given/ProjectTasks.java
@@ -24,48 +24,53 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.tools.gradle;
+package io.spine.tools.gradle.given;
 
+import org.gradle.BuildListener;
 import org.gradle.api.Project;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
 
-import java.util.Arrays;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
- * Utilities for working with {@link JavaCompile} tasks.
+ * An extractor for the {@link Project} {@linkplain org.gradle.api.Task tasks} and their arguments.
  */
-public final class JavaCompileTasks {
+class ProjectTasks {
 
-    private final TaskCollection<JavaCompile> tasks;
-
-    private JavaCompileTasks(Project project) {
-        TaskContainer allTasks = project.getTasks();
-        this.tasks = allTasks.withType(JavaCompile.class);
+    /** Prevents instantiation of this utility class. */
+    private ProjectTasks() {
     }
 
     /**
-     * Creates a new instance for the passed projects.
+     * Returns a list of project's tasks of type {@link JavaCompile}.
+     *
+     * <p>Evaluates the project in a process to trigger all tasks' arguments modifications.
+     *
+     * @param project the project to obtain tasks from
+     * @return the project {@link JavaCompile} tasks
      */
-    public static JavaCompileTasks of(Project project) {
-        checkNotNull(project);
-        return new JavaCompileTasks(project);
+    static TaskCollection<JavaCompile> acquireJavaCompileTasks(Project project) {
+        GradleInternal gradle = (GradleInternal) project.getGradle();
+        BuildListener buildListenerBroadcaster = gradle.getBuildListenerBroadcaster();
+        buildListenerBroadcaster.projectsEvaluated(project.getGradle());
+        TaskContainer tasks = project.getTasks();
+        TaskCollection<JavaCompile> javaCompileTasks = tasks.withType(JavaCompile.class);
+        return javaCompileTasks;
     }
 
     /**
-     * Adds specified arguments to all {@code JavaCompile} tasks of the project.
+     * Returns compiler arguments from the given {@code JavaCompile} task.
+     *
+     * @param task the task to obtain the arguments from
+     * @return the {@code List} of the compiler arguments
      */
-    public void addArgs(String... arguments) {
-        checkNotNull(arguments);
-        for (JavaCompile task : tasks) {
-            CompileOptions taskOptions = task.getOptions();
-            List<String> compilerArgs = taskOptions.getCompilerArgs();
-            compilerArgs.addAll(Arrays.asList(arguments));
-        }
+    static List<String> obtainCompilerArgs(JavaCompile task) {
+        CompileOptions options = task.getOptions();
+        List<String> compilerArgs = options.getCompilerArgs();
+        return compilerArgs;
     }
 }

--- a/plugin-base/src/test/java/io/spine/tools/gradle/given/StubProject.java
+++ b/plugin-base/src/test/java/io/spine/tools/gradle/given/StubProject.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.given;
+
+import io.spine.testing.TempDir;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.testfixtures.ProjectBuilder;
+
+import java.io.File;
+
+import static io.spine.tools.gradle.ProtobufTaskName.generateProto;
+import static io.spine.tools.gradle.ProtobufTaskName.generateTestProto;
+import static io.spine.tools.gradle.StandardRepos.applyStandard;
+import static org.gradle.internal.impldep.com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A helper for configuring a Gradle project for the needs of test suites.
+ *
+ * <p>NOTE: the real dependencies and their resolution in tests will often lead to relatively long
+ * execution times, the {@link io.spine.testing.SlowTest} annotation should be used for such
+ * test cases.
+ */
+public final class StubProject {
+
+    private final Project project;
+
+    private StubProject(Project project) {
+        this.project = checkNotNull(project);
+    }
+
+    /**
+     * Creates a new Gradle project for the purposes of the passed test suite class.
+     */
+    public static StubProject createFor(Class<?> testSuiteClass) {
+        File tempDir = TempDir.forClass(testSuiteClass);
+        Project project = createAt(tempDir);
+        return new StubProject(project);
+    }
+
+    /**
+     * Creates a project in the given directory.
+     *
+     * <p>The created project has:
+     * <ul>
+     *     <li>{@code java} plugin applied;
+     *     <li>{@code generateProto} task;
+     *     <li>{@code generateTestProto} task.
+     * </ul>
+     *
+     * @param projectDir the {@linkplain Project#getProjectDir() root directory} of the project
+     */
+    public static Project createAt(File projectDir) {
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(projectDir)
+                .build();
+        project.getPluginManager()
+               .apply("java");
+        project.task(generateProto.name());
+        project.task(generateTestProto.name());
+        return project;
+    }
+
+    /**
+     * Configures the project to contain the {@code mavenLocal()} and {@code mavenCentral()}
+     * repositories for proper dependency resolution.
+     */
+    public StubProject withMavenRepositories() {
+        RepositoryHandler repositories = project.getRepositories();
+        applyStandard(repositories);
+        return this;
+    }
+
+    /**
+     * Returns underlying Gradle project.
+     */
+    public Project get() {
+        return project;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>model-compiler</artifactId>
-<version>0.0.5</version>
+<version>0.0.6</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,5 +24,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("0.0.5")
+val versionToPublish: String by extra("0.0.6")
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.67")


### PR DESCRIPTION
The issue https://github.com/SpineEventEngine/model-compiler/issues/3 is no longer relevant. We're actively migrating to new Model Compiler, and not having the prefix does more harm than good.

This PR restores using the `spine-` prefix for artifacts.

It also brings `JavaCompileTasks` utility to the level of public API.