### PR TITLE
Fix extension name

### DIFF
--- a/buildSrc/src/main/groovy/slow-tests.gradle
+++ b/buildSrc/src/main/groovy/slow-tests.gradle
@@ -25,7 +25,7 @@
  */
 
 println("`slow-tests.gradle` script is deprecated. " +
-        "Please use `TestContainer.registerTestTasks()` instead.")
+        "Please use `TaskContainer.registerTestTasks()` instead.")
 
 final def slowTag = 'slow' // See io.spine.testing.SlowTest
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
@@ -33,6 +33,8 @@ import org.gradle.kotlin.dsl.register
 /**
  * Registers [slowTest][SlowTest] and [fastTest][FastTest] tasks in this [TaskContainer].
  *
+ * Slow tests are registered to run after all fast tests.
+ *
  * Usage example:
  *
  * ```
@@ -41,6 +43,7 @@ import org.gradle.kotlin.dsl.register
  * }
  * ```
  */
+@Suppress("unused")
 fun TaskContainer.registerTestTasks() {
     register<FastTest>("fastTest").let {
         register<SlowTest>("slowTest") {

--- a/license-report.md
+++ b/license-report.md
@@ -441,4 +441,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 20:52:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 21:12:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -441,4 +441,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 18:44:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 20:52:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model-compiler/src/main/kotlin/io/spine/tools/mc/gradle/McExtension.kt
+++ b/model-compiler/src/main/kotlin/io/spine/tools/mc/gradle/McExtension.kt
@@ -79,8 +79,9 @@ public abstract class McExtension {
          * Adds this extension to the given [Project] and initializes the default values.
          */
         internal fun createIn(p: Project): Unit = with(p) {
-            _debug().log("Adding the `$name` extension to the project `$p`.")
-            val extension = extensions.create(name, McExtension::class.java)
+            val extensionName: String = this@Companion.name
+            _debug().log("Adding the `$extensionName` extension to the project `$p`.")
+            val extension = extensions.create(extensionName, McExtension::class.java)
             with (extension) {
                 mainDescriptorSetFile.convention(regularFile(defaultMainDescriptors))
                 testDescriptorSetFile.convention(regularFile(defaultTestDescriptors))

--- a/model-compiler/src/test/kotlin/io/spine/tools/mc/gradle/McExtensionTest.kt
+++ b/model-compiler/src/test/kotlin/io/spine/tools/mc/gradle/McExtensionTest.kt
@@ -29,6 +29,7 @@ package io.spine.tools.mc.gradle
 import com.google.common.truth.Truth.assertThat
 import io.spine.tools.mc.checks.Severity
 import java.io.File
+import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
@@ -37,11 +38,12 @@ import org.junit.jupiter.api.Test
 
 class `'McExtension' should` {
 
+    lateinit var project: Project
     lateinit var ext: McExtension
 
     @BeforeEach
     fun prepareExtension() {
-        val project = ProjectBuilder.builder()
+        project = ProjectBuilder.builder()
             .withName("ext-test")
             .build()
         project.group = "org.example"
@@ -49,6 +51,13 @@ class `'McExtension' should` {
         project.apply(mapOf("plugin" to "java"))
         McPlugin().apply(project)
         ext = project.extensions.getByType()
+    }
+
+    @Test
+    fun `register itself with the name`() {
+        val found = project.extensions.findByName(McExtension.name)
+
+        assertThat(found).isInstanceOf(McExtension::class.java)
     }
 
     @Nested

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>model-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.75</version>
+<version>2.0.0-SNAPSHOT.76</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -26,4 +26,4 @@
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.75")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.76")


### PR DESCRIPTION
This PR fixes the bug with using a project name instead of the `McExtension.name` when creating the instance of the extension.
