### PR TITLE
Remove descriptor set file properties in `ModelCompilerOptions`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.30"
+    const val version      = "1.5.31"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -81,23 +81,23 @@
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -332,55 +332,55 @@
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -441,4 +441,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:28:49 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 20:03:56 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model-compiler/src/main/kotlin/io/spine/tools/mc/gradle/ModelCompilerOptions.kt
+++ b/model-compiler/src/main/kotlin/io/spine/tools/mc/gradle/ModelCompilerOptions.kt
@@ -27,14 +27,10 @@
 package io.spine.tools.mc.gradle
 
 import io.spine.logging.Logging
-import io.spine.tools.gradle.defaultMainDescriptors
-import io.spine.tools.gradle.defaultTestDescriptors
 import io.spine.tools.mc.checks.Severity
 import io.spine.tools.mc.gradle.ModelCompilerOptions.Companion.name
-import java.io.File
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Nested
 import org.gradle.kotlin.dsl.getByName
 
@@ -49,20 +45,6 @@ public abstract class ModelCompilerOptions {
      * @see [checks]
      */
     @get:Nested public abstract val checks: CommonChecks
-
-    /**
-     * The absolute path to the Protobuf descriptor set file in the `main` source set.
-     *
-     * The file must have the `.desc` extension.
-     */
-    public abstract val mainDescriptorSetFile: RegularFileProperty
-
-    /**
-     * The absolute path to the Protobuf descriptor set file in the `test` source set.
-     *
-     * The file must have the `.desc` extension.
-     */
-    public abstract val testDescriptorSetFile: RegularFileProperty
 
     /**
      * Configures the `checks` property using the passed action.
@@ -82,17 +64,9 @@ public abstract class ModelCompilerOptions {
         internal fun createIn(p: Project): Unit = with(p) {
             val extensionName: String = this@Companion.name
             _debug().log("Adding the `$extensionName` extension to the project `$p`.")
-            val extension = extensions.create(extensionName, ModelCompilerOptions::class.java)
-            with (extension) {
-                mainDescriptorSetFile.convention(regularFile(defaultMainDescriptors))
-                testDescriptorSetFile.convention(regularFile(defaultTestDescriptors))
-
-                checks.defaultSeverity.set(Severity.WARN)
-            }
+            val options = extensions.create(extensionName, ModelCompilerOptions::class.java)
+            options.checks.defaultSeverity.set(Severity.WARN)
         }
-
-        private fun Project.regularFile(file: File) =
-            layout.projectDirectory.file(file.toString())
     }
 }
 
@@ -100,7 +74,7 @@ public abstract class ModelCompilerOptions {
  * Obtains the extension configured in this project.
  */
 public val Project.modelCompiler: ModelCompilerOptions
-    get() = this.extensions.getByName<ModelCompilerOptions>(ModelCompilerOptions.name)
+    get() = extensions.getByName<ModelCompilerOptions>(ModelCompilerOptions.name)
 
 /**
  * Configures the extension using the passed action.

--- a/model-compiler/src/test/kotlin/io/spine/tools/mc/gradle/ModelCompilerOptionsTest.kt
+++ b/model-compiler/src/test/kotlin/io/spine/tools/mc/gradle/ModelCompilerOptionsTest.kt
@@ -28,7 +28,6 @@ package io.spine.tools.mc.gradle
 
 import com.google.common.truth.Truth.assertThat
 import io.spine.tools.mc.checks.Severity
-import java.io.File
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.testfixtures.ProjectBuilder
@@ -73,30 +72,6 @@ class `'ModelCompilerOptions' should` {
         }
         assertThat(project.modelCompiler.checks.defaultSeverity.get())
             .isEqualTo(Severity.OFF)
-    }
-
-    /**
-     * The path values hard-coded in the test below are composed using
-     * the artifact coordinates that match those specified in [prepareExtension].
-     */
-    @Nested
-    inner class `provide default` {
-
-        @Test
-        fun mainDescriptorSetFile() {
-            val file = ext.mainDescriptorSetFile.asFile.get()
-            assertPath(file)
-                .endsWith("/build/descriptors/main/org.example_ext-test_42.desc")
-        }
-
-        @Test
-        fun testDescriptorSetFile() {
-            val file = ext.testDescriptorSetFile.asFile.get()
-            assertPath(file)
-                .endsWith("/build/descriptors/test/org.example_ext-test_42_test.desc")
-        }
-
-        private fun assertPath(file: File) = assertThat(file.invariantSeparatorsPath)
     }
 
     @Nested

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>model-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.77</version>
+<version>2.0.0-SNAPSHOT.78</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -32,13 +32,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.74</version>
+    <version>2.0.0-SNAPSHOT.75</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-stdlib-jdk8</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -68,7 +68,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.74</version>
+    <version>2.0.0-SNAPSHOT.75</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -157,17 +157,17 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-compiler-embeddable</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
   </dependency>
 </dependencies>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,5 +25,5 @@
  */
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
-val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.77")
+val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.75")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.78")


### PR DESCRIPTION
This PR Removes descriptor set file properties in `ModelCompilerOptions` in favor of `Project` extensions [recently introduced](https://github.com/SpineEventEngine/tool-base/pull/2) in `tool-base`.
