### PR TITLE
Bump `tool-base`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -441,4 +441,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 17 17:17:00 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 17:02:01 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>model-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.80</version>
+<version>2.0.0-SNAPSHOT.81</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -32,7 +32,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.77</version>
+    <version>2.0.0-SNAPSHOT.78</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -68,7 +68,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.77</version>
+    <version>2.0.0-SNAPSHOT.78</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,5 +25,5 @@
  */
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.75")
-val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.77")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.80")
+val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.78")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.81")


### PR DESCRIPTION
This PR bumps the dependency on `tool-base` to the latest version.