### PR TITLE
Bump `base` and  `tool-base`

### DIFF
--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -20,4 +20,5 @@ jobs:
 
       - name: Build project and run tests
         shell: cmd
-        run: gradlew.bat build --stacktrace
+        # For the reason on `--no-daemon` see https://github.com/actions/cache/issues/454
+        run: gradlew.bat build --stacktrace --no-daemon

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -69,7 +69,7 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create" />
+      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create,stream" />
       <option name="KEEP_BUILDER_METHODS_INDENTS" value="true" />
       <arrangement>
         <groups>

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -30,5 +30,5 @@ package io.spine.internal.dependency
 // See `io.spine.internal.gradle.checkstyle.CheckStyleConfig`.
 @Suppress("unused")
 object CheckStyle {
-    const val version = "8.29"
+    const val version = "9.1"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/StringExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/StringExtensions.kt
@@ -31,5 +31,5 @@ package io.spine.internal.gradle
  * `false` otherwise.
  */
 fun String.isSnapshot(): Boolean {
-    return contains("snapshot", true)
+    return contains("snapshot", ignoreCase = true)
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/checkstyle/CheckStyleConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/checkstyle/CheckStyleConfig.kt
@@ -57,9 +57,11 @@ object CheckStyleConfig {
             plugin(CheckstylePlugin::class.java)
         }
 
+        val configDir = project.rootDir.resolve("config/quality/")
+
         with(project.the<CheckstyleExtension>()) {
             toolVersion = CheckStyle.version
-            configFile = project.rootDir.resolve("config/quality/checkstyle.xml")
+            configDirectory.set(configDir)
         }
 
         project.afterEvaluate {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
@@ -26,8 +26,6 @@
 
 package io.spine.internal.gradle.javac
 
-import org.gradle.api.GradleException
-import org.gradle.api.JavaVersion
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.process.CommandLineArgumentProvider
 
@@ -54,15 +52,6 @@ import org.gradle.process.CommandLineArgumentProvider
  *```
  */
 fun JavaCompile.configureJavac() {
-
-    if (JavaVersion.current() != JavacConfig.EXPECTED_JAVA_VERSION) {
-        throw GradleException("Spine Event Engine can be built with JDK 8 only." +
-                " Supporting JDK 11 and above at build-time is planned in 2.0 release." +
-                " Please use the pre-built binaries available in the Spine Maven repository." +
-                " See https://github.com/SpineEventEngine/base/issues/457."
-        )
-    }
-
     with(options) {
         encoding = JavacConfig.SOURCE_FILES_ENCODING
         compilerArgumentProviders.add(JavacConfig.ARGUMENTS)
@@ -74,7 +63,6 @@ fun JavaCompile.configureJavac() {
  */
 private object JavacConfig {
     const val SOURCE_FILES_ENCODING = "UTF-8"
-    val EXPECTED_JAVA_VERSION = JavaVersion.VERSION_1_8
     val ARGUMENTS = CommandLineArgumentProvider {
         listOf(
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -102,10 +102,6 @@
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## Compile, tests, and tooling
-1.  **Group** : antlr. **Name** : antlr. **Version** : 2.7.7.
-     * **Project URL:** [http://www.antlr.org/](http://www.antlr.org/)
-     * **License:** [BSD License](http://www.antlr.org/license.html)
-
 1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.48.
      * **Project URL:** [http://beust.com/jcommander](http://beust.com/jcommander)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -219,7 +215,7 @@
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 8.29.
+1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 9.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
@@ -243,7 +239,7 @@
      * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.1.4.
+1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.6.1.
      * **Project URL:** [http://picocli.info](http://picocli.info)
      * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -263,7 +259,7 @@
      * **Project URL:** [https://github.com/trustin/os-maven-plugin/](https://github.com/trustin/os-maven-plugin/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 9.9.1-6.
+1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 10.6.
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
@@ -281,7 +277,7 @@
      * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
      * **License:** [The BSD License](http://www.antlr.org/license.html)
 
-1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.8-1.
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.9.2.
      * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
      * **License:** [The BSD License](http://www.antlr.org/license.html)
 
@@ -323,6 +319,12 @@
 
 1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.7.
      * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
+     * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
+     * **License:** [Apache License 2.0](http://www.apache.org/licenses/)
+     * **License:** [LGPL 2.1](http://www.gnu.org/licenses/lgpl-2.1.html)
+     * **License:** [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
 
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
@@ -438,7 +440,12 @@
      * **Project URL:** [http://pcollections.org](http://pcollections.org)
      * **License:** [The MIT License](http://www.opensource.org/licenses/mit-license.php)
 
+1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
+     * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [WTFPL](http://www.wtfpl.net/)
+
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 21:28:18 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 17:05:07 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -448,4 +448,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 17:05:07 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 30 17:13:50 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>model-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.83</version>
+<version>2.0.0-SNAPSHOT.84</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -32,7 +32,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.80</version>
+    <version>2.0.0-SNAPSHOT.81</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -68,7 +68,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.80</version>
+    <version>2.0.0-SNAPSHOT.81</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -131,7 +131,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>
     <artifactId>checkstyle</artifactId>
-    <version>8.29</version>
+    <version>9.1</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,6 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.76")
-val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.80")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.83")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.77")
+val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.81")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.84")


### PR DESCRIPTION
This PR advances dependencies on `base`, `tool-base` ([see PR No.8](https://github.com/SpineEventEngine/tool-base/pull/8/files)), and `config`.