### PR TITLE
Migrate to Java 11

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.github/workflows/increment-guard.yml
+++ b/.github/workflows/increment-guard.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -69,7 +69,7 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create,stream" />
+      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create,stream,singleTenant,multitenant" />
       <option name="KEEP_BUILDER_METHODS_INDENTS" value="true" />
       <arrangement>
         <groups>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -635,6 +635,7 @@
     </inspection_tool>
     <inspection_tool class="RandomDoubleForRandomInteger" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ReadObjectAndWriteObjectPrivate" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantExplicitVariableType" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantImplements" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -38,5 +38,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 # Spine Model Compiler
 
+[![Ubuntu build][ubuntu-build-badge]][gh-actions]
+[![codecov.io](https://codecov.io/github/SpineEventEngine/model-compiler/coverage.svg?branch=master)](https://codecov.io/github/SpineEventEngine/model-compiler?branch=master) &nbsp;
+[![license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
+
+[gh-actions]: https://github.com/SpineEventEngine/model-compiler/actions
+[ubuntu-build-badge]: https://github.com/SpineEventEngine/model-compiler/actions/workflows/build-on-ubuntu.yml/badge.svg
+
 This repository provides the common base for language-specific build-time tools for Spine.
 
 ## Structure
 
-`tool-base` provides common components for building build-time tools, including file manipulations,
-Protobuf reflection, simple code generation, etc.
+`model-compiler` is the base Model Compiler Gradle plugin, which constitutes the shared
+language-agnostic parts of the "Greater" Model Compiler.
 
-`plugin-base` provides abstractions for building Gradle plugins.
+## JVM Version
 
-`plugin-testlib` provides test fixtures for Gradle plugins.
-
-`mc` is the base Model Compiler Gradle plugin, which constitutes the shared language-agnostic parts
-of the "Greater" Model Compiler
+The source code in this repository is built with Java 11.
 
 ## Related repositories
 
-See [SpineEventEngine/mc-java](https://github.com/SpineEventEngine/mc-java) for
-the Java-specific tools.
+* [SpineEventEngine/tool-base](https://github.com/SpineEventEngine/tool-base) —
+common code for build-time tools.
+
+* [SpineEventEngine/mc-java](https://github.com/SpineEventEngine/mc-java) —
+Java-specific tools.
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,7 +115,6 @@ subprojects {
 
     dependencies {
         errorprone(ErrorProne.core)
-        errorproneJavac(ErrorProne.javacPlugin)
 
         compileOnlyApi(FindBugs.annotations)
         compileOnlyApi(CheckerFramework.annotations)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,14 +143,14 @@ subprojects {
     JavadocConfig.applyTo(project)
     LicenseReporter.generateReportIn(project)
 
-    val javaVersion = 8
+    val javaVersion = 11
     kotlin {
         applyJvmToolchain(javaVersion)
         explicitApi()
     }
 
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+        kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
         setFreeCompilerArgs()
     }
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -151,10 +151,6 @@
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.8.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
-     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
-     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
 
 1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
@@ -448,4 +444,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 01 20:55:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Dec 05 14:53:01 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>model-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.85</version>
+<version>2.0.0-SNAPSHOT.86</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -117,11 +117,6 @@ all modules and does not describe the project structure per-subproject.
     <artifactId>error_prone_type_annotations</artifactId>
     <version>2.8.0</version>
     <scope>provided</scope>
-  </dependency>
-  <dependency>
-    <groupId>com.google.errorprone</groupId>
-    <artifactId>javac</artifactId>
-    <version>9+181-r4173-1</version>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -26,4 +26,4 @@
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.77")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.82")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.85")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.86")


### PR DESCRIPTION
This changeset updates the build target of the `model-compler` module to Java 11.

The latest `config` changes were applied.

Also, the `README.md` was refreshed.

The library version is set to `2.0.0-SNAPSHOT.86`.